### PR TITLE
Pass additional props to ScrollView, fix circle proptypes

### DIFF
--- a/src/Circles.js
+++ b/src/Circles.js
@@ -1,6 +1,11 @@
 
 import React, { Component } from 'react'
-import {　View,　PixelRatio,　TouchableWithoutFeedback　} from 'react-native'
+import {
+  PixelRatio,
+  TouchableWithoutFeedback,
+  View,
+  ViewPropTypes,
+} from 'react-native'
 import {PropTypes} from 'prop-types'
 
 const styles = {
@@ -30,9 +35,9 @@ class Circles extends Component {
     return {
       store: PropTypes.object,
       emitter: PropTypes.object,
-      circleWrapperStyle: PropTypes.object,
-      circleDefaultStyle: PropTypes.object,
-      circleActiveStyle: PropTypes.object,
+      circleWrapperStyle: ViewPropTypes.style,
+      circleDefaultStyle: ViewPropTypes.style,
+      circleActiveStyle: ViewPropTypes.style,
       children: PropTypes.any
     }
   }

--- a/src/Circles.js
+++ b/src/Circles.js
@@ -1,6 +1,7 @@
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import {　View,　PixelRatio,　TouchableWithoutFeedback　} from 'react-native'
+import {PropTypes} from 'prop-types'
 
 const styles = {
   circleWrapper: {

--- a/src/FixedSizeView.js
+++ b/src/FixedSizeView.js
@@ -1,6 +1,7 @@
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { View } from 'react-native'
+import {PropTypes} from 'prop-types'
 
 class FixedSizeView extends Component {
   static get propTypes() {

--- a/src/FixedSizeView.js
+++ b/src/FixedSizeView.js
@@ -25,11 +25,11 @@ class FixedSizeView extends Component {
   render() {
     const { width, height } = this.props.store.getState()
 
-    return (
+    return width ? (
       <View style={{width, height}}>
         {this.props.children}
       </View>
-    )
+    ) : null;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import ReactNative, {
   Platform,
   ScrollView,
   View,
-  ViewPagerAndroid
+  ViewPagerAndroid,
+  ViewPropTypes,
 } from 'react-native'
 import {PropTypes} from 'prop-types'
 
@@ -116,9 +117,9 @@ export default class SwipeALot extends Component {
   static get propTypes() {
     return {
       wrapperStyle: PropTypes.object,
-      circleWrapperStyle: PropTypes.object,
-      circleDefaultStyle: PropTypes.object,
-      circleActiveStyle: PropTypes.object,
+      circleWrapperStyle: ViewPropTypes.style,
+      circleDefaultStyle: ViewPropTypes.style,
+      circleActiveStyle: ViewPropTypes.style,
       children: PropTypes.any,
       emitter: PropTypes.object,
       autoplay: PropTypes.object,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, {
   Component,
-  PropTypes
 } from 'react'
 import ReactNative, {
   Platform,
@@ -8,6 +7,7 @@ import ReactNative, {
   View,
   ViewPagerAndroid
 } from 'react-native'
+import {PropTypes} from 'prop-types'
 
 import Circles from './Circles'
 import FixedSizeView from './FixedSizeView'

--- a/src/index.js
+++ b/src/index.js
@@ -128,8 +128,20 @@ export default class SwipeALot extends Component {
   }
 
   render() {
+    const {
+      wrapperStyle,
+      circleWrapperStyle,
+      circleDefaultStyle,
+      circleActiveStyle,
+      children,
+      emitter,
+      autoplay,
+      onSetActivePage,
+      ...props,
+    } = this.props;
+
     return (
-      <View style={[this.props.wrapperStyle, {flex: 1}]} onLayout={() => {
+      <View style={[wrapperStyle, {flex: 1}]} onLayout={() => {
           const page = this.getPage()
           this.swipeToPage(page)
         }}>
@@ -157,8 +169,10 @@ export default class SwipeALot extends Component {
                     height
                   })
                 }}
-                automaticallyAdjustContentInsets={false}>
-                {React.Children.map(this.props.children, (c, i) => {
+                automaticallyAdjustContentInsets={false}
+                {...props}
+              >
+                {React.Children.map(children, (c, i) => {
                   return <FixedSizeView store={this.store} key={`view${i}`}>{c}</FixedSizeView>
                 })}
               </ScrollView>
@@ -175,7 +189,7 @@ export default class SwipeALot extends Component {
                 style={{
                   flex: 1
                 }}>
-                {React.Children.map(this.props.children, (c) => {
+                {React.Children.map(children, (c) => {
                   return <View>{c}</View>
                 })}
               </ViewPagerAndroid>
@@ -183,10 +197,10 @@ export default class SwipeALot extends Component {
           }
         })()}
         <Circles store={this.store} emitter={this.emitter}
-          circleWrapperStyle={this.props.circleWrapperStyle}
-          circleDefaultStyle={this.props.circleDefaultStyle}
-          circleActiveStyle={this.props.circleActiveStyle}>
-          {this.props.children}
+          circleWrapperStyle={circleWrapperStyle}
+          circleDefaultStyle={circleDefaultStyle}
+          circleActiveStyle={circleActiveStyle}>
+          {children}
         </Circles>
       </View>
     )


### PR DESCRIPTION
- Passes any additional props down to the `ScrollView`. I needed this to add `style` and can add a special property for that if that's more appropriate, note that `wrapperStyle` didn't work in my case since I needed to set `overflow: visible` on the scrollview.
- Fixes passing StyleSheet styles to the circle props without warnings. 
- Don't render items before onLayout. Fixes layout issue where flex text (sub) children would not wrap if they where first rendered without bounds. 

Based on the fork in #8 